### PR TITLE
Fix Slash Command Interaction Type

### DIFF
--- a/.changeset/large-spoons-move.md
+++ b/.changeset/large-spoons-move.md
@@ -1,0 +1,5 @@
+---
+'jellycommands': patch
+---
+
+switch slash commands from CommandInteraction to ChatInputCommandInteraction

--- a/docs/guide/commands/files.md
+++ b/docs/guide/commands/files.md
@@ -75,7 +75,7 @@ export default command({
 
 ### interaction
 
-- Type: [`CommandInteraction`](https://discord.js.org/#/docs/discord.js/main/class/CommandInteraction)
+- Type: [`ChatInputCommandInteraction`](https://discord.js.org/#/docs/discord.js/main/class/CommandInteractionOptionResolver)
 
 The interaction that command relates to
 

--- a/packages/jellycommands/src/commands/types/commands/Command.ts
+++ b/packages/jellycommands/src/commands/types/commands/Command.ts
@@ -1,5 +1,5 @@
 import { type AutocompleteInteraction, ApplicationCommandOptionType } from 'discord.js';
-import type { ApplicationCommandOption, CommandInteraction } from 'discord.js';
+import type { ApplicationCommandOption, ChatInputCommandInteraction } from 'discord.js';
 import type { APIApplicationCommandOption } from 'discord-api-types/v10';
 import { ApplicationCommandType } from 'discord-api-types/v10';
 import type { JellyApplicationCommandOption } from './types';
@@ -17,11 +17,11 @@ export type AutocompleteHandler = (options: {
     client: JellyCommands;
 }) => Awaitable<any | void>;
 
-export class Command extends BaseCommand<CommandOptions, CommandInteraction> {
+export class Command extends BaseCommand<CommandOptions, ChatInputCommandInteraction> {
     public readonly type = ApplicationCommandType.ChatInput;
 
     constructor(
-        run: BaseCommand<CommandOptions, CommandInteraction>['run'],
+        run: BaseCommand<CommandOptions, ChatInputCommandInteraction>['run'],
         options: CommandOptions,
         readonly autocomplete?: AutocompleteHandler,
     ) {
@@ -67,7 +67,7 @@ export class Command extends BaseCommand<CommandOptions, CommandInteraction> {
 
 export const command = (
     options: CommandOptions & {
-        run: BaseCommandCallback<CommandInteraction>;
+        run: BaseCommandCallback<ChatInputCommandInteraction>;
         autocomplete?: AutocompleteHandler;
     },
 ) => {


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist

- [ ] Related issue: <!-- If this pr has a issue with it then replace this comment with the issue number e.g. #11 -->
- [x] Changesets done <!-- If this pr includes a change, generate it by running pnpx changeset (PATCH only till 1.0) -->

### Body
<!-- Here you can put what the pr is about -->

Currently a slash command interaction is typed as [CommandInteraction](https://discord.js.org/#/docs/discord.js/main/class/CommandInteraction) but the correct one is [ChatInputCommandInteraction](https://discord.js.org/#/docs/discord.js/main/class/ChatInputCommandInteraction)