### PR TITLE
Fix/partial localization object

### DIFF
--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -60,7 +60,7 @@ The name of the command
 
 ##### descriptionLocalizations
 
-- Type: `Record<Locale, string>`
+- Type: `Partial<Record<Locale, string>>`
 
 The localizations for users not in english, you can view the available [`Locale` options here](https://discord.js.org/#/docs/discord.js/main/typedef/Locale)
 
@@ -139,7 +139,7 @@ The name of the command
 
 ### nameLocalizations
 
-- Type: `Record<Locale, string>`
+- Type: `Partial<Record<Locale, string>>`
 
 The localizations for users not in english, you can view the available [`Locale` options here](https://discord.js.org/#/docs/discord.js/main/typedef/Locale)
 

--- a/packages/jellycommands/src/commands/types/commands/options.ts
+++ b/packages/jellycommands/src/commands/types/commands/options.ts
@@ -12,7 +12,7 @@ export interface CommandOptions extends BaseOptions {
     /**
      * Localize a command descriptions to different languages
      */
-    descriptionLocalizations?: Record<Locale, string>;
+    descriptionLocalizations?: Partial<Record<Locale, string>>;
 
     /**
      * Options for the slash command

--- a/packages/jellycommands/src/commands/types/options.ts
+++ b/packages/jellycommands/src/commands/types/options.ts
@@ -13,7 +13,7 @@ export interface BaseOptions {
     /**
      * Localize a command name to different languages
      */
-    nameLocalizations?: Record<Locale, string>;
+    nameLocalizations?: Partial<Record<Locale, string>>;
 
     /**
      * Is the command in dev mode or not


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist

- [ ] Related issue: <!-- If this pr has a issue with it then replace this comment with the issue number e.g. #11 -->
- [ ] Changesets done <!-- If this pr includes a change, generate it by running pnpx changeset (PATCH only till 1.0) -->

### Body
<!-- Here you can put what the pr is about -->
I had a issue where the `nameLocalizations` & `descriptionLocalizations` types were `Record<enum, string>` meaning all enum members were required. This pr just changes the type to `Partial<Record<enum, string>>` so that all enum members are optional 