### PR TITLE
Fix/partial localization object type

### DIFF
--- a/.changeset/cool-mugs-knock.md
+++ b/.changeset/cool-mugs-knock.md
@@ -1,0 +1,5 @@
+---
+'jellycommands': patch
+---
+
+change `nameLocalizations` & `descriptionLocalizations` to a partial type

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -60,7 +60,7 @@ The name of the command
 
 ##### descriptionLocalizations
 
-- Type: `Record<Locale, string>`
+- Type: `Partial<Record<Locale, string>>`
 
 The localizations for users not in english, you can view the available [`Locale` options here](https://discord.js.org/#/docs/discord.js/main/typedef/Locale)
 
@@ -139,7 +139,7 @@ The name of the command
 
 ### nameLocalizations
 
-- Type: `Record<Locale, string>`
+- Type: `Partial<Record<Locale, string>>`
 
 The localizations for users not in english, you can view the available [`Locale` options here](https://discord.js.org/#/docs/discord.js/main/typedef/Locale)
 

--- a/packages/jellycommands/src/commands/types/commands/options.ts
+++ b/packages/jellycommands/src/commands/types/commands/options.ts
@@ -12,7 +12,7 @@ export interface CommandOptions extends BaseOptions {
     /**
      * Localize a command descriptions to different languages
      */
-    descriptionLocalizations?: Record<Locale, string>;
+    descriptionLocalizations?: Partial<Record<Locale, string>>;
 
     /**
      * Options for the slash command

--- a/packages/jellycommands/src/commands/types/options.ts
+++ b/packages/jellycommands/src/commands/types/options.ts
@@ -13,7 +13,7 @@ export interface BaseOptions {
     /**
      * Localize a command name to different languages
      */
-    nameLocalizations?: Record<Locale, string>;
+    nameLocalizations?: Partial<Record<Locale, string>>;
 
     /**
      * Is the command in dev mode or not


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist
- [x] Changesets done <!-- If this pr includes a change, generate it by running pnpx changeset (PATCH only till 1.0) -->

### Body
<!-- Here you can put what the pr is about -->
Original pr: #152 (vscode had a moment with last pr)

I had a issue where the `nameLocalizations` & `descriptionLocalizations` types were `Record<enum, string>` meaning all enum members were required. This pr just changes the type to `Partial<Record<enum, string>>` so that all enum members are optional 