### PR TITLE
fix: event type for register

### DIFF
--- a/.changeset/clean-bikes-live.md
+++ b/.changeset/clean-bikes-live.md
@@ -1,5 +1,0 @@
----
-'jellycommands': patch
----
-
-fix event type for register

--- a/.changeset/clean-bikes-live.md
+++ b/.changeset/clean-bikes-live.md
@@ -1,0 +1,5 @@
+---
+'jellycommands': patch
+---
+
+fix event type for register

--- a/packages/jellycommands/src/events/register.ts
+++ b/packages/jellycommands/src/events/register.ts
@@ -6,7 +6,7 @@ export const registerEvents = async (
     client: JellyCommands,
     items: string | Array<string | Event<any>>,
 ) => {
-    const events = new Set<Event>();
+    const events = new Set<Event<any>>();
 
     await read(items, (event) => {
         if (!(event instanceof Event))


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist

- [x] Related issue: #163 
- [x] Changesets done <!-- If this pr includes a change, generate it by running pnpx changeset (PATCH only till 1.0) -->
- [ ] Docs Updated: Doc change not required

### Body
<!-- Here you can put what the pr is about -->
Change 
https://github.com/ghostdevv/jellycommands/blob/b607c2a9ce9ac32292cb81faef611d2e583b624f/packages/jellycommands/src/events/register.ts#L9
to
```ts
const events = new Set<Event<any>();
```
