### PR TITLE
Fix: add guard for dev mode

### DIFF
--- a/.changeset/rich-bugs-tickle.md
+++ b/.changeset/rich-bugs-tickle.md
@@ -1,0 +1,5 @@
+---
+'jellycommands': patch
+---
+
+add a guard to catch no guild id when dev mode enabled

--- a/docs/guide/commands/dev.md
+++ b/docs/guide/commands/dev.md
@@ -18,6 +18,10 @@ const client = new JellyCommands({
 
 For additional options, see [dev options](/api/client#dev).
 
+:::tip NOTE
+If dev mode is enabled in any way, atleast one guild ID must be specified within [`dev.guilds`](/api/client#dev)
+:::
+
 ## Global Dev Mode
 
 Adding `dev: true` to every command *(and remembering to remove it)* can be tedious. [global dev mode](/api/client#dev-global) makes this easier.

--- a/docs/guide/commands/dev.md
+++ b/docs/guide/commands/dev.md
@@ -19,7 +19,7 @@ const client = new JellyCommands({
 For additional options, see [dev options](/api/client#dev).
 
 :::tip NOTE
-If dev mode is enabled in any way, atleast one guild ID must be specified within [`dev.guilds`](/api/client#dev)
+If `dev` mode is enabled, at least one guild id must be specified within [`dev.guilds`](/api/client#dev)
 :::
 
 ## Global Dev Mode

--- a/packages/jellycommands/src/JellyCommands.ts
+++ b/packages/jellycommands/src/JellyCommands.ts
@@ -52,6 +52,19 @@ export class JellyCommands extends Client {
             const commands = await resolveCommands(this, this.joptions.commands);
             const commandIdMap = await getCommandIdMap(this, commands);
 
+            // If dev is enabled in some way, make sure they have at least one guild id
+            if (this.joptions.dev?.guilds?.length) {
+                const hasDevCommand = Array.from(commands.commands).some(
+                    (command) => command.options.dev,
+                );
+
+                if (hasDevCommand || this.joptions.dev?.global) {
+                    throw new Error(
+                        'You must provide at least one guild id in the dev guilds array to use dev commands',
+                    );
+                }
+            }
+
             // Whenever there is a interactionCreate event respond to it
             this.on('interactionCreate', (interaction) => {
                 // prettier-ignore

--- a/packages/jellycommands/src/JellyCommands.ts
+++ b/packages/jellycommands/src/JellyCommands.ts
@@ -56,12 +56,13 @@ export class JellyCommands extends Client {
             );
 
             // If dev is enabled in some way, make sure they have at least one guild id
-            if (devCommandInSet || this.joptions.dev?.global) {
-                if (!this.joptions.dev?.guilds?.length) {
-                    throw new Error(
-                        'You must provide at least one guild id in the dev guilds array to use dev commands',
-                    );
-                }
+            if (
+                (devCommandInSet || this.joptions.dev?.global) &&
+                !this.joptions.dev?.guilds?.length
+            ) {
+                throw new Error(
+                    'You must provide at least one guild id in the dev guilds array to use dev commands',
+                );
             }
 
             // Whenever there is a interactionCreate event respond to it

--- a/packages/jellycommands/src/JellyCommands.ts
+++ b/packages/jellycommands/src/JellyCommands.ts
@@ -51,14 +51,13 @@ export class JellyCommands extends Client {
         if (this.joptions.commands) {
             const commands = await resolveCommands(this, this.joptions.commands);
             const commandIdMap = await getCommandIdMap(this, commands);
+            const devCommandInSet = Array.from(commands.commands).some(
+                (command) => command.options.dev,
+            );
 
             // If dev is enabled in some way, make sure they have at least one guild id
-            if (!this.joptions.dev?.guilds?.length) {
-                const hasDevCommand = Array.from(commands.commands).some(
-                    (command) => command.options.dev,
-                );
-
-                if (hasDevCommand || this.joptions.dev?.global) {
+            if (devCommandInSet || this.joptions.dev?.global) {
+                if (!this.joptions.dev?.guilds?.length) {
                     throw new Error(
                         'You must provide at least one guild id in the dev guilds array to use dev commands',
                     );

--- a/packages/jellycommands/src/JellyCommands.ts
+++ b/packages/jellycommands/src/JellyCommands.ts
@@ -53,7 +53,7 @@ export class JellyCommands extends Client {
             const commandIdMap = await getCommandIdMap(this, commands);
 
             // If dev is enabled in some way, make sure they have at least one guild id
-            if (this.joptions.dev?.guilds?.length) {
+            if (!this.joptions.dev?.guilds?.length) {
                 const hasDevCommand = Array.from(commands.commands).some(
                     (command) => command.options.dev,
                 );

--- a/packages/jellycommands/src/JellyCommands.ts
+++ b/packages/jellycommands/src/JellyCommands.ts
@@ -51,18 +51,16 @@ export class JellyCommands extends Client {
         if (this.joptions.commands) {
             const commands = await resolveCommands(this, this.joptions.commands);
             const commandIdMap = await getCommandIdMap(this, commands);
-            const devCommandInSet = Array.from(commands.commands).some(
-                (command) => command.options.dev,
-            );
-
-            // If dev is enabled in some way, make sure they have at least one guild id
-            if (
-                (devCommandInSet || this.joptions.dev?.global) &&
-                !this.joptions.dev?.guilds?.length
-            ) {
-                throw new Error(
-                    'You must provide at least one guild id in the dev guilds array to use dev commands',
+            if (!this.joptions.dev?.guilds?.length) {
+                const hasDevCommand = Array.from(commands.commands).some(
+                    (command) => command.options.dev,
                 );
+
+                // If dev is enabled in some way, make sure they have at least one guild id
+                if (this.joptions.dev?.global || hasDevCommand)
+                    throw new Error(
+                        'You must provide at least one guild id in the dev guilds array to use dev commands',
+                    );
             }
 
             // Whenever there is a interactionCreate event respond to it


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist

- [x] Related issue: #105 
- [x] Changesets done 
- [x] Docs Updated 

### Body
<!-- Here you can put what the pr is about -->
This pull request adds a new check to ensure that developers who enable dev mode with `dev.global` have at least one guild ID provided in the `dev.guilds` array. If there are no guild IDs provided, the code will throw an error.

This check also takes into account any dev commands that may be present in the commands set. If there are any dev commands, but no guild IDs are provided, the code will also throw an error
