### PR TITLE
breaking: better logging

### DIFF
--- a/.changeset/cyan-beers-heal.md
+++ b/.changeset/cyan-beers-heal.md
@@ -1,0 +1,5 @@
+---
+"jellycommands": minor
+---
+
+breaking: better logging

--- a/packages/jellycommands/src/commands/cache.ts
+++ b/packages/jellycommands/src/commands/cache.ts
@@ -10,38 +10,38 @@ export async function getCommandIdMap(
 ): Promise<CommandIDMap> {
     // If cache is disabled always register
     if (!client.joptions.cache) {
-        client.debug('Cache Disabled, registering Commands');
+        client.log.debug('Cache Disabled, registering Commands');
         return await registerCommands(client, commands);
     }
 
-    client.debug('Loading Cache');
+    client.log.debug('Loading Cache');
 
     const idResolver = new CommandIdResolver();
     const cache = new CommandCache();
 
     if (cache.validate(commands.commands)) {
-        client.debug('Cache is valid');
+        client.log.debug('Cache is valid');
 
         // Attempt to resolve command id map
         const commandIdMap = idResolver.get(commands.commands);
 
         if (commandIdMap) {
-            client.debug('Command Id Resolution success');
+            client.log.debug('Command Id Resolution success');
             return commandIdMap;
         }
 
         // This will only run if a CommandManager isn't returned above
-        client.debug('Id Resolver failed, reregistering commands');
+        client.log.debug('Id Resolver failed, reregistering commands');
     }
 
-    client.debug('Cache is invalid, registering commands');
+    client.log.debug('Cache is invalid, registering commands');
 
     const commandIdMap = await registerCommands(client, commands);
 
-    client.debug('Cache Updated');
+    client.log.debug('Cache Updated');
     cache.set(commands.commands);
 
-    client.debug('Id Resolver Updated');
+    client.log.debug('Id Resolver Updated');
     idResolver.set(commandIdMap);
 
     return commandIdMap;

--- a/packages/jellycommands/src/utils/logger.ts
+++ b/packages/jellycommands/src/utils/logger.ts
@@ -1,0 +1,24 @@
+import { JellyCommands } from '../JellyCommands';
+
+export interface Logger {
+    (...messages: any[]): void;
+    log: (...messages: any[]) => void;
+    debug: (...messages: any[]) => void;
+    error: (...errors: any[]) => void;
+}
+
+export function createLogger(client: JellyCommands): Logger {
+    const methods = {
+        log: (...messages: any[]) =>
+            console.log('\x1b[1m\x1b[35m[JellyCommands Log]\x1b[22m\x1b[39m', ...messages),
+        error: (...errors: any[]) =>
+            console.error('\x1b[1m\x1b[31m[JellyCommands Error]\x1b[22m\x1b[39m', ...errors),
+        debug: (...messages: any[]) => {
+            if (!client.joptions.debug) {
+                console.debug('\x1b[1m\x1b[34m[JellyCommands Debug]\x1b[22m\x1b[39m', ...messages);
+            }
+        },
+    };
+
+    return Object.assign(methods.log, methods);
+}


### PR DESCRIPTION
<!-- Thank you for the pr! Make sure you follow the checklist below: -->

### Checklist

- [x] Related issue: #185 
- [x] Changesets done <!-- If this pr includes a change, generate it by running pnpx changeset (PATCH only till 1.0) -->
- [ ] Docs Updated <!-- Did you update the docs? -->

### Body

Introduces a better `client.log`, for those relying on `client.debug()` you should migrate to `client.log.debug()`
